### PR TITLE
Add request template

### DIFF
--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Action.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Action.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Action;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Action
@@ -203,7 +205,25 @@ namespace MAVSDK_CSharp.Plugins
             });
         }
 
+        public IObservable<float> GetTakeoffAltitude()
+        {
+            return Observable.Create<float>(observer =>
+            {
+                var getTakeoffAltitudeResponse = _actionServiceClient.GetTakeoffAltitude(new GetTakeoffAltitudeRequest());
+                var actionResult = getTakeoffAltitudeResponse.ActionResult;
+                if (actionResult.Result == ActionResult.Types.Result.Success)
+                {
+                    observer.OnNext(getTakeoffAltitudeResponse.Altitude);
+                }
+                else
+                {
+                    observer.OnError(new ActionException(actionResult.Result, actionResult.ResultStr));
+                }
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> SetTakeoffAltitude()
         {
@@ -224,7 +244,25 @@ namespace MAVSDK_CSharp.Plugins
             });
         }
 
+        public IObservable<float> GetMaximumSpeed()
+        {
+            return Observable.Create<float>(observer =>
+            {
+                var getMaximumSpeedResponse = _actionServiceClient.GetMaximumSpeed(new GetMaximumSpeedRequest());
+                var actionResult = getMaximumSpeedResponse.ActionResult;
+                if (actionResult.Result == ActionResult.Types.Result.Success)
+                {
+                    observer.OnNext(getMaximumSpeedResponse.Speed);
+                }
+                else
+                {
+                    observer.OnError(new ActionException(actionResult.Result, actionResult.ResultStr));
+                }
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> SetMaximumSpeed()
         {
@@ -245,7 +283,25 @@ namespace MAVSDK_CSharp.Plugins
             });
         }
 
+        public IObservable<float> GetReturnToLaunchAltitude()
+        {
+            return Observable.Create<float>(observer =>
+            {
+                var getReturnToLaunchAltitudeResponse = _actionServiceClient.GetReturnToLaunchAltitude(new GetReturnToLaunchAltitudeRequest());
+                var actionResult = getReturnToLaunchAltitudeResponse.ActionResult;
+                if (actionResult.Result == ActionResult.Types.Result.Success)
+                {
+                    observer.OnNext(getReturnToLaunchAltitudeResponse.RelativeAltitudeM);
+                }
+                else
+                {
+                    observer.OnError(new ActionException(actionResult.Result, actionResult.ResultStr));
+                }
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> SetReturnToLaunchAltitude()
         {

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Calibration.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Calibration.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Calibration;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Calibration

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Camera.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Camera.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Camera;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Camera

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Core.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Core.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Core;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Core
@@ -43,6 +45,16 @@ namespace MAVSDK_CSharp.Plugins
                     }));
         }
 
+        public IObservable<List<PluginInfo>> ListRunningPlugins()
+        {
+            return Observable.Create<List<PluginInfo>>(observer =>
+            {
+                var listRunningPluginsResponse = _coreServiceClient.ListRunningPlugins(new ListRunningPluginsRequest());
+                observer.OnNext(listRunningPluginsResponse.PluginInfo.ToList());
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
     }
 }

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Gimbal.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Gimbal.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Gimbal;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Gimbal

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Info.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Info.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Info;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Info
@@ -32,6 +34,24 @@ namespace MAVSDK_CSharp.Plugins
             }
         }
 
+        public IObservable<Version> GetVersion()
+        {
+            return Observable.Create<Version>(observer =>
+            {
+                var getVersionResponse = _infoServiceClient.GetVersion(new GetVersionRequest());
+                var infoResult = getVersionResponse.InfoResult;
+                if (infoResult.Result == InfoResult.Types.Result.Success)
+                {
+                    observer.OnNext(getVersionResponse.Version);
+                }
+                else
+                {
+                    observer.OnError(new InfoException(infoResult.Result, infoResult.ResultStr));
+                }
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
     }
 }

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Mission.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Mission.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Mission;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Mission
@@ -62,7 +64,25 @@ namespace MAVSDK_CSharp.Plugins
             });
         }
 
+        public IObservable<List<MissionItem>> DownloadMission()
+        {
+            return Observable.Create<List<MissionItem>>(observer =>
+            {
+                var downloadMissionResponse = _missionServiceClient.DownloadMission(new DownloadMissionRequest());
+                var missionResult = downloadMissionResponse.MissionResult;
+                if (missionResult.Result == MissionResult.Types.Result.Success)
+                {
+                    observer.OnNext(downloadMissionResponse.MissionItems.ToList());
+                }
+                else
+                {
+                    observer.OnError(new MissionException(missionResult.Result, missionResult.ResultStr));
+                }
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> CancelMissionDownload()
         {
@@ -132,7 +152,17 @@ namespace MAVSDK_CSharp.Plugins
             });
         }
 
+        public IObservable<bool> IsMissionFinished()
+        {
+            return Observable.Create<bool>(observer =>
+            {
+                var isMissionFinishedResponse = _missionServiceClient.IsMissionFinished(new IsMissionFinishedRequest());
+                observer.OnNext(isMissionFinishedResponse.IsFinished);
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<MissionProgress> MissionProgress()
         {
@@ -155,7 +185,17 @@ namespace MAVSDK_CSharp.Plugins
                     }));
         }
 
+        public IObservable<bool> GetReturnToLaunchAfterMission()
+        {
+            return Observable.Create<bool>(observer =>
+            {
+                var getReturnToLaunchAfterMissionResponse = _missionServiceClient.GetReturnToLaunchAfterMission(new GetReturnToLaunchAfterMissionRequest());
+                observer.OnNext(getReturnToLaunchAfterMissionResponse.Enable);
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> SetReturnToLaunchAfterMission()
         {

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Offboard.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Offboard.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Offboard;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Offboard
@@ -70,7 +72,17 @@ namespace MAVSDK_CSharp.Plugins
             });
         }
 
+        public IObservable<bool> IsActive()
+        {
+            return Observable.Create<bool>(observer =>
+            {
+                var isActiveResponse = _offboardServiceClient.IsActive(new IsActiveRequest());
+                observer.OnNext(isActiveResponse.IsActive);
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> SetAttitude()
         {

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Param.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Param.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Param;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Param
@@ -32,7 +34,25 @@ namespace MAVSDK_CSharp.Plugins
             }
         }
 
+        public IObservable<int> GetIntParam()
+        {
+            return Observable.Create<int>(observer =>
+            {
+                var getIntParamResponse = _paramServiceClient.GetIntParam(new GetIntParamRequest());
+                var paramResult = getIntParamResponse.ParamResult;
+                if (paramResult.Result == ParamResult.Types.Result.Success)
+                {
+                    observer.OnNext(getIntParamResponse.Value);
+                }
+                else
+                {
+                    observer.OnError(new ParamException(paramResult.Result, paramResult.ResultStr));
+                }
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> SetIntParam()
         {
@@ -53,7 +73,25 @@ namespace MAVSDK_CSharp.Plugins
             });
         }
 
+        public IObservable<float> GetFloatParam()
+        {
+            return Observable.Create<float>(observer =>
+            {
+                var getFloatParamResponse = _paramServiceClient.GetFloatParam(new GetFloatParamRequest());
+                var paramResult = getFloatParamResponse.ParamResult;
+                if (paramResult.Result == ParamResult.Types.Result.Success)
+                {
+                    observer.OnNext(getFloatParamResponse.Value);
+                }
+                else
+                {
+                    observer.OnError(new ParamException(paramResult.Result, paramResult.ResultStr));
+                }
 
+                observer.OnCompleted();
+                return Task.FromResult(Disposable.Empty);
+            });
+        }
 
         public IObservable<Unit> SetFloatParam()
         {

--- a/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Telemetry.cs
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/Plugins/Telemetry.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.Telemetry;
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class Telemetry
@@ -64,11 +66,11 @@ namespace MAVSDK_CSharp.Plugins
                     }));
         }
 
-        public IObservable<Boolean> InAir()
+        public IObservable<bool> InAir()
         {
             return Observable.Using(() => _telemetryServiceClient.SubscribeInAir(new SubscribeInAirRequest()).ResponseStream,
                 reader => Observable.Create(
-                    async (IObserver<Boolean> observer) =>
+                    async (IObserver<bool> observer) =>
                     {
                         try
                         {
@@ -85,11 +87,11 @@ namespace MAVSDK_CSharp.Plugins
                     }));
         }
 
-        public IObservable<Boolean> Armed()
+        public IObservable<bool> Armed()
         {
             return Observable.Using(() => _telemetryServiceClient.SubscribeArmed(new SubscribeArmedRequest()).ResponseStream,
                 reader => Observable.Create(
-                    async (IObserver<Boolean> observer) =>
+                    async (IObserver<bool> observer) =>
                     {
                         try
                         {

--- a/MAVSDK-CSharp/MAVSDK-CSharp/templates/file.j2
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/templates/file.j2
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Mavsdk.Rpc.{{ plugin_name.upper_camel_case }};
 
+using Version = Mavsdk.Rpc.Info.Version;
+
 namespace MAVSDK_CSharp.Plugins
 {
     public class {{ plugin_name.upper_camel_case }}

--- a/MAVSDK-CSharp/MAVSDK-CSharp/templates/request.j2
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/templates/request.j2
@@ -1,1 +1,32 @@
+public IObservable<{% if return_type.is_repeated %}List<{{ return_type.inner_name }}>{% else %}{{ return_type.name }}{% endif %}> {{ name.upper_camel_case }}()
+{
+    return Observable.Create<{% if return_type.is_repeated %}List<{{ return_type.inner_name }}>{% else %}{{ return_type.name }}{% endif %}>(observer =>
+    {
+        var {{ name.lower_camel_case }}Response = _{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(new {{ name.upper_camel_case }}Request());
 
+        {%- if has_result %}
+        var {{ plugin_name.lower_camel_case }}Result = {{ name.lower_camel_case }}Response.{{ plugin_name.upper_camel_case }}Result;
+        if ({{ plugin_name.lower_camel_case }}Result.Result == {{ plugin_name.upper_camel_case }}Result.Types.Result.Success)
+        {
+            {%- if return_type.is_repeated %}
+            observer.OnNext({{ name.lower_camel_case }}Response.{{ return_name.upper_camel_case }}.ToList());
+            {%- else %}
+            observer.OnNext({{ name.lower_camel_case }}Response.{{ return_name.upper_camel_case }});
+            {%- endif %}
+        }
+        else
+        {
+            observer.OnError(new {{ plugin_name.upper_camel_case }}Exception({{ plugin_name.lower_camel_case }}Result.Result, {{ plugin_name.lower_camel_case }}Result.ResultStr));
+        }
+        {%- else %}
+            {%- if return_type.is_repeated %}
+        observer.OnNext({{ name.lower_camel_case }}Response.{{ return_name.upper_camel_case }}.ToList());
+            {%- else %}
+        observer.OnNext({{ name.lower_camel_case }}Response.{{ return_name.upper_camel_case }});
+            {%- endif %}
+        {%- endif %}
+
+        observer.OnCompleted();
+        return Task.FromResult(Disposable.Empty);
+    });
+}

--- a/MAVSDK-CSharp/MAVSDK-CSharp/templates/type_conversions
+++ b/MAVSDK-CSharp/MAVSDK-CSharp/templates/type_conversions
@@ -1,12 +1,12 @@
 {
-    "double": "Double",
-    "float": "Float",
-    "int64_t": "Long",
-    "uint64_t": "Long",
-    "int32_t": "Integer",
-    "bool": "Boolean",
-    "std::string": "String",
+    "double": "double",
+    "float": "float",
+    "int64_t": "long",
+    "uint64_t": "ulong",
+    "int32_t": "int",
+    "bool": "bool",
+    "std::string": "string",
     "std::byte": "ByteString",
-    "uint32_t": "Integer",
+    "uint32_t": "uint",
     "repeated": { "prefix": "List<", "suffix": ">" }
 }

--- a/MAVSDK-CSharp/MAVSDK.CSharp.ConsoleClient/Program.cs
+++ b/MAVSDK-CSharp/MAVSDK.CSharp.ConsoleClient/Program.cs
@@ -29,9 +29,14 @@ namespace MAVSDK.CSharp.ConsoleClient
                 .DistinctUntilChanged()
                 .Where(altitude => altitude >= 0)
                 .Subscribe(Observer.Create<double>(altitude => Console.WriteLine($"altitude: {altitude}"), _ => { }));
-
-            // Arm, takeoff, wait 5 seconds and land.
+            
+            // Print the takeoff altitude.
             var action = new Action(Host, Port);
+            action.GetTakeoffAltitude()
+                .Do(altitude => Console.WriteLine($"Takeoff altitude: {altitude}"))
+                .Subscribe();
+            
+            // Arm, takeoff, wait 5 seconds and land.
             var tcs = new TaskCompletionSource<bool>();
             action.Arm()
                 .Concat(action.Takeoff())


### PR DESCRIPTION
* Add `request.j2`
* Update `type_conversions` to reflect actual C# types (base on the [protobuf docs](https://developers.google.com/protocol-buffers/docs/proto3#scalar)

Note: I added a weird `using Version = Mavsdk.Rpc.Info.Version;` to deal with a conflict with `System.Version`. I believe it should anyway become `Info.Version` once we add `struct.j2` (instead of using the gRPC types directly).

Next steps:
* Deal with function parameters (e.g. in Swift: [{% for param in params %}](https://github.com/mavlink/MAVSDK-Swift/blob/master/templates/request.j2#L2))
* Add `struct.j2` and use it instead of the gRPC types
* Add `enum.j2` and use it instead of the gRPC types