### PR TITLE
Pass RPC parameters

### DIFF
--- a/MAVSDK-CSharp/MAVSDK/Plugins/Action.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Action.cs
@@ -196,7 +196,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<float>(observer =>
             {
-                var getTakeoffAltitudeResponse = _actionServiceClient.GetTakeoffAltitude(new GetTakeoffAltitudeRequest());
+                var request = new GetTakeoffAltitudeRequest();
+                var getTakeoffAltitudeResponse = _actionServiceClient.GetTakeoffAltitude(request);
                 var actionResult = getTakeoffAltitudeResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -235,7 +236,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<float>(observer =>
             {
-                var getMaximumSpeedResponse = _actionServiceClient.GetMaximumSpeed(new GetMaximumSpeedRequest());
+                var request = new GetMaximumSpeedRequest();
+                var getMaximumSpeedResponse = _actionServiceClient.GetMaximumSpeed(request);
                 var actionResult = getMaximumSpeedResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -274,7 +276,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<float>(observer =>
             {
-                var getReturnToLaunchAltitudeResponse = _actionServiceClient.GetReturnToLaunchAltitude(new GetReturnToLaunchAltitudeRequest());
+                var request = new GetReturnToLaunchAltitudeRequest();
+                var getReturnToLaunchAltitudeResponse = _actionServiceClient.GetReturnToLaunchAltitude(request);
                 var actionResult = getReturnToLaunchAltitudeResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Action.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Action.cs
@@ -25,7 +25,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var armResponse = _actionServiceClient.Arm(new ArmRequest());
+                var request = new ArmRequest();
+                var armResponse = _actionServiceClient.Arm(request);
                 var actionResult = armResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -44,7 +45,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var disarmResponse = _actionServiceClient.Disarm(new DisarmRequest());
+                var request = new DisarmRequest();
+                var disarmResponse = _actionServiceClient.Disarm(request);
                 var actionResult = disarmResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -63,7 +65,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var takeoffResponse = _actionServiceClient.Takeoff(new TakeoffRequest());
+                var request = new TakeoffRequest();
+                var takeoffResponse = _actionServiceClient.Takeoff(request);
                 var actionResult = takeoffResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -82,7 +85,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var landResponse = _actionServiceClient.Land(new LandRequest());
+                var request = new LandRequest();
+                var landResponse = _actionServiceClient.Land(request);
                 var actionResult = landResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -101,7 +105,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var rebootResponse = _actionServiceClient.Reboot(new RebootRequest());
+                var request = new RebootRequest();
+                var rebootResponse = _actionServiceClient.Reboot(request);
                 var actionResult = rebootResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -120,7 +125,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var killResponse = _actionServiceClient.Kill(new KillRequest());
+                var request = new KillRequest();
+                var killResponse = _actionServiceClient.Kill(request);
                 var actionResult = killResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -139,7 +145,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var returnToLaunchResponse = _actionServiceClient.ReturnToLaunch(new ReturnToLaunchRequest());
+                var request = new ReturnToLaunchRequest();
+                var returnToLaunchResponse = _actionServiceClient.ReturnToLaunch(request);
                 var actionResult = returnToLaunchResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -158,7 +165,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var transitionToFixedWingResponse = _actionServiceClient.TransitionToFixedWing(new TransitionToFixedWingRequest());
+                var request = new TransitionToFixedWingRequest();
+                var transitionToFixedWingResponse = _actionServiceClient.TransitionToFixedWing(request);
                 var actionResult = transitionToFixedWingResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -177,7 +185,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var transitionToMulticopterResponse = _actionServiceClient.TransitionToMulticopter(new TransitionToMulticopterRequest());
+                var request = new TransitionToMulticopterRequest();
+                var transitionToMulticopterResponse = _actionServiceClient.TransitionToMulticopter(request);
                 var actionResult = transitionToMulticopterResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -213,11 +222,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetTakeoffAltitude()
+        public IObservable<Unit> SetTakeoffAltitude(float altitude)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setTakeoffAltitudeResponse = _actionServiceClient.SetTakeoffAltitude(new SetTakeoffAltitudeRequest());
+                var request = new SetTakeoffAltitudeRequest();
+                request.Altitude = altitude;
+                var setTakeoffAltitudeResponse = _actionServiceClient.SetTakeoffAltitude(request);
                 var actionResult = setTakeoffAltitudeResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -253,11 +264,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetMaximumSpeed()
+        public IObservable<Unit> SetMaximumSpeed(float speed)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setMaximumSpeedResponse = _actionServiceClient.SetMaximumSpeed(new SetMaximumSpeedRequest());
+                var request = new SetMaximumSpeedRequest();
+                request.Speed = speed;
+                var setMaximumSpeedResponse = _actionServiceClient.SetMaximumSpeed(request);
                 var actionResult = setMaximumSpeedResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {
@@ -293,11 +306,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetReturnToLaunchAltitude()
+        public IObservable<Unit> SetReturnToLaunchAltitude(float relativeAltitudeM)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setReturnToLaunchAltitudeResponse = _actionServiceClient.SetReturnToLaunchAltitude(new SetReturnToLaunchAltitudeRequest());
+                var request = new SetReturnToLaunchAltitudeRequest();
+                request.RelativeAltitudeM = relativeAltitudeM;
+                var setReturnToLaunchAltitudeResponse = _actionServiceClient.SetReturnToLaunchAltitude(request);
                 var actionResult = setReturnToLaunchAltitudeResponse.ActionResult;
                 if (actionResult.Result == ActionResult.Types.Result.Success)
                 {

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Calibration.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Calibration.cs
@@ -153,7 +153,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                _calibrationServiceClient.Cancel(new CancelRequest());
+                var request = new CancelRequest();
+                _calibrationServiceClient.Cancel(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Camera.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Camera.cs
@@ -25,7 +25,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var takePhotoResponse = _cameraServiceClient.TakePhoto(new TakePhotoRequest());
+                var request = new TakePhotoRequest();
+                var takePhotoResponse = _cameraServiceClient.TakePhoto(request);
                 var cameraResult = takePhotoResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -40,11 +41,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> StartPhotoInterval()
+        public IObservable<Unit> StartPhotoInterval(float intervalS)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var startPhotoIntervalResponse = _cameraServiceClient.StartPhotoInterval(new StartPhotoIntervalRequest());
+                var request = new StartPhotoIntervalRequest();
+                request.IntervalS = intervalS;
+                var startPhotoIntervalResponse = _cameraServiceClient.StartPhotoInterval(request);
                 var cameraResult = startPhotoIntervalResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -63,7 +66,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var stopPhotoIntervalResponse = _cameraServiceClient.StopPhotoInterval(new StopPhotoIntervalRequest());
+                var request = new StopPhotoIntervalRequest();
+                var stopPhotoIntervalResponse = _cameraServiceClient.StopPhotoInterval(request);
                 var cameraResult = stopPhotoIntervalResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -82,7 +86,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var startVideoResponse = _cameraServiceClient.StartVideo(new StartVideoRequest());
+                var request = new StartVideoRequest();
+                var startVideoResponse = _cameraServiceClient.StartVideo(request);
                 var cameraResult = startVideoResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -101,7 +106,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var stopVideoResponse = _cameraServiceClient.StopVideo(new StopVideoRequest());
+                var request = new StopVideoRequest();
+                var stopVideoResponse = _cameraServiceClient.StopVideo(request);
                 var cameraResult = stopVideoResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -120,7 +126,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var startVideoStreamingResponse = _cameraServiceClient.StartVideoStreaming(new StartVideoStreamingRequest());
+                var request = new StartVideoStreamingRequest();
+                var startVideoStreamingResponse = _cameraServiceClient.StartVideoStreaming(request);
                 var cameraResult = startVideoStreamingResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -139,7 +146,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var stopVideoStreamingResponse = _cameraServiceClient.StopVideoStreaming(new StopVideoStreamingRequest());
+                var request = new StopVideoStreamingRequest();
+                var stopVideoStreamingResponse = _cameraServiceClient.StopVideoStreaming(request);
                 var cameraResult = stopVideoStreamingResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -154,11 +162,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetMode()
+        public IObservable<Unit> SetMode(CameraMode cameraMode)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setModeResponse = _cameraServiceClient.SetMode(new SetModeRequest());
+                var request = new SetModeRequest();
+                request.CameraMode = cameraMode;
+                var setModeResponse = _cameraServiceClient.SetMode(request);
                 var cameraResult = setModeResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {
@@ -299,11 +309,13 @@ namespace MAVSDK.Plugins
                     }));
         }
 
-        public IObservable<Unit> SetSetting()
+        public IObservable<Unit> SetSetting(Setting setting)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setSettingResponse = _cameraServiceClient.SetSetting(new SetSettingRequest());
+                var request = new SetSettingRequest();
+                request.Setting = setting;
+                var setSettingResponse = _cameraServiceClient.SetSetting(request);
                 var cameraResult = setSettingResponse.CameraResult;
                 if (cameraResult.Result == CameraResult.Types.Result.Success)
                 {

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Core.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Core.cs
@@ -46,7 +46,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<List<PluginInfo>>(observer =>
             {
-                var listRunningPluginsResponse = _coreServiceClient.ListRunningPlugins(new ListRunningPluginsRequest());
+                var request = new ListRunningPluginsRequest();
+                var listRunningPluginsResponse = _coreServiceClient.ListRunningPlugins(request);
                 observer.OnNext(listRunningPluginsResponse.PluginInfo.ToList());
 
                 observer.OnCompleted();

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Gimbal.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Gimbal.cs
@@ -21,11 +21,14 @@ namespace MAVSDK.Plugins
             _gimbalServiceClient = new GimbalService.GimbalServiceClient(channel);
         }
 
-        public IObservable<Unit> SetPitchAndYaw()
+        public IObservable<Unit> SetPitchAndYaw(float pitchDeg, float yawDeg)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setPitchAndYawResponse = _gimbalServiceClient.SetPitchAndYaw(new SetPitchAndYawRequest());
+                var request = new SetPitchAndYawRequest();
+                request.PitchDeg = pitchDeg;
+                request.YawDeg = yawDeg;
+                var setPitchAndYawResponse = _gimbalServiceClient.SetPitchAndYaw(request);
                 var gimbalResult = setPitchAndYawResponse.GimbalResult;
                 if (gimbalResult.Result == GimbalResult.Types.Result.Success)
                 {

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Info.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Info.cs
@@ -25,7 +25,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Version>(observer =>
             {
-                var getVersionResponse = _infoServiceClient.GetVersion(new GetVersionRequest());
+                var request = new GetVersionRequest();
+                var getVersionResponse = _infoServiceClient.GetVersion(request);
                 var infoResult = getVersionResponse.InfoResult;
                 if (infoResult.Result == InfoResult.Types.Result.Success)
                 {

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Mission.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Mission.cs
@@ -55,7 +55,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<List<MissionItem>>(observer =>
             {
-                var downloadMissionResponse = _missionServiceClient.DownloadMission(new DownloadMissionRequest());
+                var request = new DownloadMissionRequest();
+                var downloadMissionResponse = _missionServiceClient.DownloadMission(request);
                 var missionResult = downloadMissionResponse.MissionResult;
                 if (missionResult.Result == MissionResult.Types.Result.Success)
                 {
@@ -143,7 +144,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<bool>(observer =>
             {
-                var isMissionFinishedResponse = _missionServiceClient.IsMissionFinished(new IsMissionFinishedRequest());
+                var request = new IsMissionFinishedRequest();
+                var isMissionFinishedResponse = _missionServiceClient.IsMissionFinished(request);
                 observer.OnNext(isMissionFinishedResponse.IsFinished);
 
                 observer.OnCompleted();
@@ -176,7 +178,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<bool>(observer =>
             {
-                var getReturnToLaunchAfterMissionResponse = _missionServiceClient.GetReturnToLaunchAfterMission(new GetReturnToLaunchAfterMissionRequest());
+                var request = new GetReturnToLaunchAfterMissionRequest();
+                var getReturnToLaunchAfterMissionResponse = _missionServiceClient.GetReturnToLaunchAfterMission(request);
                 observer.OnNext(getReturnToLaunchAfterMissionResponse.Enable);
 
                 observer.OnCompleted();

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Mission.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Mission.cs
@@ -21,11 +21,13 @@ namespace MAVSDK.Plugins
             _missionServiceClient = new MissionService.MissionServiceClient(channel);
         }
 
-        public IObservable<Unit> UploadMission()
+        public IObservable<Unit> UploadMission(List<MissionItem> missionItems)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var uploadMissionResponse = _missionServiceClient.UploadMission(new UploadMissionRequest());
+                var request = new UploadMissionRequest();
+                request.MissionItems.AddRange(missionItems);
+                var uploadMissionResponse = _missionServiceClient.UploadMission(request);
                 var missionResult = uploadMissionResponse.MissionResult;
                 if (missionResult.Result == MissionResult.Types.Result.Success)
                 {
@@ -44,7 +46,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                _missionServiceClient.CancelMissionUpload(new CancelMissionUploadRequest());
+                var request = new CancelMissionUploadRequest();
+                _missionServiceClient.CancelMissionUpload(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);
@@ -76,7 +79,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                _missionServiceClient.CancelMissionDownload(new CancelMissionDownloadRequest());
+                var request = new CancelMissionDownloadRequest();
+                _missionServiceClient.CancelMissionDownload(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);
@@ -87,7 +91,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var startMissionResponse = _missionServiceClient.StartMission(new StartMissionRequest());
+                var request = new StartMissionRequest();
+                var startMissionResponse = _missionServiceClient.StartMission(request);
                 var missionResult = startMissionResponse.MissionResult;
                 if (missionResult.Result == MissionResult.Types.Result.Success)
                 {
@@ -106,7 +111,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var pauseMissionResponse = _missionServiceClient.PauseMission(new PauseMissionRequest());
+                var request = new PauseMissionRequest();
+                var pauseMissionResponse = _missionServiceClient.PauseMission(request);
                 var missionResult = pauseMissionResponse.MissionResult;
                 if (missionResult.Result == MissionResult.Types.Result.Success)
                 {
@@ -121,11 +127,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetCurrentMissionItemIndex()
+        public IObservable<Unit> SetCurrentMissionItemIndex(int index)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setCurrentMissionItemIndexResponse = _missionServiceClient.SetCurrentMissionItemIndex(new SetCurrentMissionItemIndexRequest());
+                var request = new SetCurrentMissionItemIndexRequest();
+                request.Index = index;
+                var setCurrentMissionItemIndexResponse = _missionServiceClient.SetCurrentMissionItemIndex(request);
                 var missionResult = setCurrentMissionItemIndexResponse.MissionResult;
                 if (missionResult.Result == MissionResult.Types.Result.Success)
                 {
@@ -187,11 +195,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetReturnToLaunchAfterMission()
+        public IObservable<Unit> SetReturnToLaunchAfterMission(bool enable)
         {
             return Observable.Create<Unit>(observer =>
             {
-                _missionServiceClient.SetReturnToLaunchAfterMission(new SetReturnToLaunchAfterMissionRequest());
+                var request = new SetReturnToLaunchAfterMissionRequest();
+                request.Enable = enable;
+                _missionServiceClient.SetReturnToLaunchAfterMission(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Offboard.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Offboard.cs
@@ -25,7 +25,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var startResponse = _offboardServiceClient.Start(new StartRequest());
+                var request = new StartRequest();
+                var startResponse = _offboardServiceClient.Start(request);
                 var offboardResult = startResponse.OffboardResult;
                 if (offboardResult.Result == OffboardResult.Types.Result.Success)
                 {
@@ -44,7 +45,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<Unit>(observer =>
             {
-                var stopResponse = _offboardServiceClient.Stop(new StopRequest());
+                var request = new StopRequest();
+                var stopResponse = _offboardServiceClient.Stop(request);
                 var offboardResult = stopResponse.OffboardResult;
                 if (offboardResult.Result == OffboardResult.Types.Result.Success)
                 {
@@ -72,66 +74,78 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetAttitude()
+        public IObservable<Unit> SetAttitude(Attitude attitude)
         {
             return Observable.Create<Unit>(observer =>
             {
-                _offboardServiceClient.SetAttitude(new SetAttitudeRequest());
+                var request = new SetAttitudeRequest();
+                request.Attitude = attitude;
+                _offboardServiceClient.SetAttitude(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);
             });
         }
 
-        public IObservable<Unit> SetActuatorControl()
+        public IObservable<Unit> SetActuatorControl(ActuatorControl actuatorControl)
         {
             return Observable.Create<Unit>(observer =>
             {
-                _offboardServiceClient.SetActuatorControl(new SetActuatorControlRequest());
+                var request = new SetActuatorControlRequest();
+                request.ActuatorControl = actuatorControl;
+                _offboardServiceClient.SetActuatorControl(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);
             });
         }
 
-        public IObservable<Unit> SetAttitudeRate()
+        public IObservable<Unit> SetAttitudeRate(AttitudeRate attitudeRate)
         {
             return Observable.Create<Unit>(observer =>
             {
-                _offboardServiceClient.SetAttitudeRate(new SetAttitudeRateRequest());
+                var request = new SetAttitudeRateRequest();
+                request.AttitudeRate = attitudeRate;
+                _offboardServiceClient.SetAttitudeRate(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);
             });
         }
 
-        public IObservable<Unit> SetPositionNed()
+        public IObservable<Unit> SetPositionNed(PositionNEDYaw positionNedYaw)
         {
             return Observable.Create<Unit>(observer =>
             {
-                _offboardServiceClient.SetPositionNed(new SetPositionNedRequest());
+                var request = new SetPositionNedRequest();
+                request.PositionNedYaw = positionNedYaw;
+                _offboardServiceClient.SetPositionNed(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);
             });
         }
 
-        public IObservable<Unit> SetVelocityBody()
+        public IObservable<Unit> SetVelocityBody(VelocityBodyYawspeed velocityBodyYawspeed)
         {
             return Observable.Create<Unit>(observer =>
             {
-                _offboardServiceClient.SetVelocityBody(new SetVelocityBodyRequest());
+                var request = new SetVelocityBodyRequest();
+                request.VelocityBodyYawspeed = velocityBodyYawspeed;
+                _offboardServiceClient.SetVelocityBody(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);
             });
         }
 
-        public IObservable<Unit> SetVelocityNed()
+        public IObservable<Unit> SetVelocityNed(VelocityNEDYaw velocityNedYaw)
         {
             return Observable.Create<Unit>(observer =>
             {
-                _offboardServiceClient.SetVelocityNed(new SetVelocityNedRequest());
+                var request = new SetVelocityNedRequest();
+                request.VelocityNedYaw = velocityNedYaw;
+                _offboardServiceClient.SetVelocityNed(request);
                 observer.OnCompleted();
 
                 return Task.FromResult(Disposable.Empty);

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Offboard.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Offboard.cs
@@ -63,7 +63,8 @@ namespace MAVSDK.Plugins
         {
             return Observable.Create<bool>(observer =>
             {
-                var isActiveResponse = _offboardServiceClient.IsActive(new IsActiveRequest());
+                var request = new IsActiveRequest();
+                var isActiveResponse = _offboardServiceClient.IsActive(request);
                 observer.OnNext(isActiveResponse.IsActive);
 
                 observer.OnCompleted();

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Param.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Param.cs
@@ -43,11 +43,14 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetIntParam()
+        public IObservable<Unit> SetIntParam(string name, int value)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setIntParamResponse = _paramServiceClient.SetIntParam(new SetIntParamRequest());
+                var request = new SetIntParamRequest();
+                request.Name = name;
+                request.Value = value;
+                var setIntParamResponse = _paramServiceClient.SetIntParam(request);
                 var paramResult = setIntParamResponse.ParamResult;
                 if (paramResult.Result == ParamResult.Types.Result.Success)
                 {
@@ -84,11 +87,14 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<Unit> SetFloatParam()
+        public IObservable<Unit> SetFloatParam(string name, float value)
         {
             return Observable.Create<Unit>(observer =>
             {
-                var setFloatParamResponse = _paramServiceClient.SetFloatParam(new SetFloatParamRequest());
+                var request = new SetFloatParamRequest();
+                request.Name = name;
+                request.Value = value;
+                var setFloatParamResponse = _paramServiceClient.SetFloatParam(request);
                 var paramResult = setFloatParamResponse.ParamResult;
                 if (paramResult.Result == ParamResult.Types.Result.Success)
                 {

--- a/MAVSDK-CSharp/MAVSDK/Plugins/Param.cs
+++ b/MAVSDK-CSharp/MAVSDK/Plugins/Param.cs
@@ -21,11 +21,13 @@ namespace MAVSDK.Plugins
             _paramServiceClient = new ParamService.ParamServiceClient(channel);
         }
 
-        public IObservable<int> GetIntParam()
+        public IObservable<int> GetIntParam(string name)
         {
             return Observable.Create<int>(observer =>
             {
-                var getIntParamResponse = _paramServiceClient.GetIntParam(new GetIntParamRequest());
+                var request = new GetIntParamRequest();
+                request.Name = name;
+                var getIntParamResponse = _paramServiceClient.GetIntParam(request);
                 var paramResult = getIntParamResponse.ParamResult;
                 if (paramResult.Result == ParamResult.Types.Result.Success)
                 {
@@ -60,11 +62,13 @@ namespace MAVSDK.Plugins
             });
         }
 
-        public IObservable<float> GetFloatParam()
+        public IObservable<float> GetFloatParam(string name)
         {
             return Observable.Create<float>(observer =>
             {
-                var getFloatParamResponse = _paramServiceClient.GetFloatParam(new GetFloatParamRequest());
+                var request = new GetFloatParamRequest();
+                request.Name = name;
+                var getFloatParamResponse = _paramServiceClient.GetFloatParam(request);
                 var paramResult = getFloatParamResponse.ParamResult;
                 if (paramResult.Result == ParamResult.Types.Result.Success)
                 {

--- a/MAVSDK-CSharp/MAVSDK/templates/call.j2
+++ b/MAVSDK-CSharp/MAVSDK/templates/call.j2
@@ -1,8 +1,19 @@
-public IObservable<Unit> {{ name.upper_camel_case }}()
+public IObservable<Unit> {{ name.upper_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %})
 {
     return Observable.Create<Unit>(observer =>
     {
-        {% if has_result %}var {{ name.lower_camel_case }}Response = {% endif %}_{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(new {{ name.upper_camel_case }}Request());
+        var request = new {{ name.upper_camel_case }}Request();
+        {% if has_result %}var {{ name.lower_camel_case }}Response = {% endif %}_{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(request);
+        
+        {%- for param in params %}
+          {%- if param.type_info.is_primitive %}
+        request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
+          {%- elif param.type_info.is_repeated %}
+        request.{{ param.name.upper_camel_case }}.AddRange({{ param.name.lower_camel_case }});
+          {%- else %}
+        request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
+          {%- endif %}
+        {%- endfor %}
 
         {%- if has_result %}
         var {{ plugin_name.lower_camel_case }}Result = {{ name.lower_camel_case }}Response.{{ plugin_name.upper_camel_case }}Result;

--- a/MAVSDK-CSharp/MAVSDK/templates/call.j2
+++ b/MAVSDK-CSharp/MAVSDK/templates/call.j2
@@ -3,8 +3,6 @@ public IObservable<Unit> {{ name.upper_camel_case }}({% for param in params %}{{
     return Observable.Create<Unit>(observer =>
     {
         var request = new {{ name.upper_camel_case }}Request();
-        {% if has_result %}var {{ name.lower_camel_case }}Response = {% endif %}_{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(request);
-        
         {%- for param in params %}
           {%- if param.type_info.is_primitive %}
         request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
@@ -14,6 +12,7 @@ public IObservable<Unit> {{ name.upper_camel_case }}({% for param in params %}{{
         request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
           {%- endif %}
         {%- endfor %}
+        {% if has_result %}var {{ name.lower_camel_case }}Response = {% endif %}_{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(request);
 
         {%- if has_result %}
         var {{ plugin_name.lower_camel_case }}Result = {{ name.lower_camel_case }}Response.{{ plugin_name.upper_camel_case }}Result;

--- a/MAVSDK-CSharp/MAVSDK/templates/request.j2
+++ b/MAVSDK-CSharp/MAVSDK/templates/request.j2
@@ -1,8 +1,20 @@
-public IObservable<{% if return_type.is_repeated %}List<{{ return_type.inner_name }}>{% else %}{{ return_type.name }}{% endif %}> {{ name.upper_camel_case }}()
+public IObservable<{% if return_type.is_repeated %}List<{{ return_type.inner_name }}>{% else %}{{ return_type.name }}{% endif %}> {{ name.upper_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %})
 {
     return Observable.Create<{% if return_type.is_repeated %}List<{{ return_type.inner_name }}>{% else %}{{ return_type.name }}{% endif %}>(observer =>
     {
-        var {{ name.lower_camel_case }}Response = _{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(new {{ name.upper_camel_case }}Request());
+        var request = new {{ name.upper_camel_case }}Request();
+          {%- for param in params %}
+            {%- if param.type_info.is_primitive %}
+          request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
+            {%- elif param.type_info.is_repeated %}
+          // TODO correct from Java code
+          request.{{ param.name.upper_camel_case }}.AddRange({{ param.name.lower_camel_case }}.stream().map(elem -> elem.rpc{{ param.type_info.inner_name }}())::iterator)
+            {%- else %}
+          // TODO correct from Java code
+          request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }}.rpc{{ param.type_info.name }}();
+            {%- endif %}
+          {%- endfor %}
+        var {{ name.lower_camel_case }}Response = _{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(request);
 
         {%- if has_result %}
         var {{ plugin_name.lower_camel_case }}Result = {{ name.lower_camel_case }}Response.{{ plugin_name.upper_camel_case }}Result;

--- a/MAVSDK-CSharp/MAVSDK/templates/request.j2
+++ b/MAVSDK-CSharp/MAVSDK/templates/request.j2
@@ -7,11 +7,9 @@ public IObservable<{% if return_type.is_repeated %}List<{{ return_type.inner_nam
           {%- if param.type_info.is_primitive %}
         request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
           {%- elif param.type_info.is_repeated %}
-        // TODO correct from Java code
-        //request.{{ param.name.upper_camel_case }}.AddRange({{ param.name.lower_camel_case }}.stream().map(elem -> elem.rpc{{ param.type_info.inner_name }}())::iterator)
+        request.{{ param.name.upper_camel_case }}.AddRange({{ param.name.lower_camel_case }});
           {%- else %}
-        // TODO correct from Java code
-        //request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }}.rpc{{ param.type_info.name }}();
+        request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
           {%- endif %}
         {%- endfor %}
         var {{ name.lower_camel_case }}Response = _{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(request);

--- a/MAVSDK-CSharp/MAVSDK/templates/request.j2
+++ b/MAVSDK-CSharp/MAVSDK/templates/request.j2
@@ -3,17 +3,17 @@ public IObservable<{% if return_type.is_repeated %}List<{{ return_type.inner_nam
     return Observable.Create<{% if return_type.is_repeated %}List<{{ return_type.inner_name }}>{% else %}{{ return_type.name }}{% endif %}>(observer =>
     {
         var request = new {{ name.upper_camel_case }}Request();
-          {%- for param in params %}
-            {%- if param.type_info.is_primitive %}
-          request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
-            {%- elif param.type_info.is_repeated %}
-          // TODO correct from Java code
-          request.{{ param.name.upper_camel_case }}.AddRange({{ param.name.lower_camel_case }}.stream().map(elem -> elem.rpc{{ param.type_info.inner_name }}())::iterator)
-            {%- else %}
-          // TODO correct from Java code
-          request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }}.rpc{{ param.type_info.name }}();
-            {%- endif %}
-          {%- endfor %}
+        {%- for param in params %}
+          {%- if param.type_info.is_primitive %}
+        request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }};
+          {%- elif param.type_info.is_repeated %}
+        // TODO correct from Java code
+        //request.{{ param.name.upper_camel_case }}.AddRange({{ param.name.lower_camel_case }}.stream().map(elem -> elem.rpc{{ param.type_info.inner_name }}())::iterator)
+          {%- else %}
+        // TODO correct from Java code
+        //request.{{ param.name.upper_camel_case }} = {{ param.name.lower_camel_case }}.rpc{{ param.type_info.name }}();
+          {%- endif %}
+        {%- endfor %}
         var {{ name.lower_camel_case }}Response = _{{ plugin_name.lower_camel_case }}ServiceClient.{{ name.upper_camel_case }}(request);
 
         {%- if has_result %}


### PR DESCRIPTION
Method parameters are entirely missing from requests like uploading mission or getting MAVLink parameters.
A copy-paste from [Java templates](https://github.com/mavlink/MAVSDK-Java/tree/master/sdk/templates) @480bdc8 made some method parameters appear (`string`s), still no luck with `UploadMission()` where a collection of MissionItems is expected.

Once the parameters are there, the TODO parts will need to be adjusted (converted from Java).